### PR TITLE
Adding a UI refresh rate to flutter compass

### DIFF
--- a/android/src/main/kotlin/com/hemanthraj/fluttercompass/FlutterCompassPlugin.kt
+++ b/android/src/main/kotlin/com/hemanthraj/fluttercompass/FlutterCompassPlugin.kt
@@ -33,7 +33,7 @@ class FlutterCompassPlugin private constructor(context: Context, sensorType: Int
 
   override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
     sensorEventListener = createSensorEventListener(events)
-    sensorManager.registerListener(sensorEventListener, sensor, SensorManager.SENSOR_DELAY_NORMAL)
+    sensorManager.registerListener(sensorEventListener, sensor, SensorManager.SENSOR_DELAY_UI)
   }
 
   override fun onCancel(arguments: Any?) {


### PR DESCRIPTION
This SENSOR_DELAY value matches the iOS refresh rate better. Someone else reported this issue: https://github.com/hemanthrajv/flutter_compass/issues/6