### PR TITLE
Sensor support check(Android)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this plugin, add `flutter_compass` as a [dependency in your pubspec.yaml 
 
 ```yaml
 dependencies:
-  flutter_compass: '^0.3.4'
+  flutter_compass: '^0.3.6'
 ```
 
 ### iOS

--- a/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
+++ b/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
@@ -33,10 +33,17 @@ public final class FlutterCompassPlugin implements StreamHandler {
 
 
     public void onListen(Object arguments, EventSink events) {
-        sensorEventListener = createSensorEventListener(events);
-        sensorManager.registerListener(sensorEventListener, this.sensor, SensorManager.SENSOR_DELAY_UI);
-        if (currentAzimuth != null) {
-            events.success(currentAzimuth);
+        // Added check for the sensor, if null then the device does not have the TYPE_ROTATION_VECTOR sensor
+        if(sensor != null) {
+            sensorEventListener = createSensorEventListener(events);
+            sensorManager.registerListener(sensorEventListener, this.sensor, SensorManager.SENSOR_DELAY_UI);
+            if (currentAzimuth != null) {
+                events.success(currentAzimuth);
+            }
+        } else {
+            // Send null to Flutter side
+            events.success(null);
+//                events.error("Sensor Null", "No sensor was found", "The device does not have any sensor");
         }
     }
 

--- a/example/README.md
+++ b/example/README.md
@@ -31,13 +31,36 @@ class _MyAppState extends State<MyApp> {
         appBar: new AppBar(
           title: const Text('Flutter Compass'),
         ),
-        body: new Container(
-          alignment: Alignment.center,
-          color: Colors.white,
-          child: new Transform.rotate(
-            angle: ((_direction ?? 0) * (math.pi / 180) * -1),
-            child: new Image.asset('assets/compass.jpg'),
-          ),
+        body: StreamBuilder<double>(
+          stream: FlutterCompass.events,
+          builder: (context, snapshot) {
+            if (snapshot.hasError) {
+              return Text('Error reading heading: ${snapshot.error}');
+            }
+
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return Center(
+                child: CircularProgressIndicator(),
+              );
+            }
+
+            double direction = snapshot.data;
+
+            // if direction is null, then device does not support this sensor
+            // show error message
+            if (direction == null)
+              return Center(
+                child: Text("Device does not have sensors !"),
+              );
+
+            return Container(
+              alignment: Alignment.center,
+              child: Transform.rotate(
+                angle: ((direction ?? 0) * (math.pi / 180) * -1),
+                child: Image.asset('assets/compass.jpg'),
+              ),
+            );
+          },
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -94,17 +94,20 @@ class _MyAppState extends State<MyApp> {
           return Text('Error reading heading: ${snapshot.error}');
         }
 
-        if (!snapshot.hasData) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
           return Center(
-            child: Container(
-              width: 32,
-              height: 32,
-              child: CircularProgressIndicator(),
-            ),
+            child: CircularProgressIndicator(),
           );
         }
 
         double direction = snapshot.data;
+
+        // if direction is null, then device does not support this sensor
+        // show error message
+        if (direction == null)
+          return Center(
+            child: Text("Device does not have sensors !"),
+          );
 
         return Container(
           alignment: Alignment.center,


### PR DESCRIPTION
because the sensor object in Android will be null if the device does not have the specified sensor, i added a check if the sensor is null, we emit `null` to the Stream so it can be checked in Flutter side and we can display a message like _Device not supported_ .
I also updated the README files.