### PR TITLE
removed log spam on ios

### DIFF
--- a/ios/Classes/SwiftFlutterCompassPlugin.swift
+++ b/ios/Classes/SwiftFlutterCompassPlugin.swift
@@ -34,7 +34,6 @@ public class SwiftFlutterCompassPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
-        print(newHeading.magneticHeading);
         if(newHeading.headingAccuracy>0){
             let heading:CLLocationDirection!;
             heading = newHeading.magneticHeading;


### PR DESCRIPTION
There is too much log spam in xcode when using this plugin. Removed a print statement that should not be included in a production code.