### PR TITLE
Android: don't add roll into heading calculation.

### DIFF
--- a/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
+++ b/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
@@ -65,7 +65,7 @@ public final class FlutterCompassPlugin implements StreamHandler {
                     double[] v = new double[3];
                     v[0] = newAzimuth;
                     v[1] = azimuthForCameraMode;
-                    v[2] = null;
+                    v[2] = -1;
                     events.success(v);
                 }
             }

--- a/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
+++ b/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
@@ -19,6 +19,7 @@ public final class FlutterCompassPlugin implements StreamHandler {
     
     private double newAzimuth;
     private double filter;
+    private int lastAccuracy;
     private SensorEventListener sensorEventListener;
 
     private final SensorManager sensorManager;
@@ -37,9 +38,6 @@ public final class FlutterCompassPlugin implements StreamHandler {
         if(sensor != null) {
             sensorEventListener = createSensorEventListener(events);
             sensorManager.registerListener(sensorEventListener, this.sensor, SensorManager.SENSOR_DELAY_UI);
-            if (currentAzimuth != null) {
-                events.success(currentAzimuth);
-            }
         } else {
             // Send null to Flutter side
             events.success(null);
@@ -54,6 +52,7 @@ public final class FlutterCompassPlugin implements StreamHandler {
     private SensorEventListener createSensorEventListener(final EventSink events) {
         return new SensorEventListener() {
             public void onAccuracyChanged(Sensor sensor, int accuracy) {
+                lastAccuracy = accuracy;
             }
 
             public void onSensorChanged(SensorEvent event) {
@@ -61,7 +60,13 @@ public final class FlutterCompassPlugin implements StreamHandler {
                 newAzimuth = (Math.toDegrees((double) SensorManager.getOrientation(rMat, orientation)[0]) + (double) 360) % (double) 360;
                 if (currentAzimuth == null || Math.abs(currentAzimuth - newAzimuth) >= filter) {
                     currentAzimuth = newAzimuth;
-                    events.success(newAzimuth);
+
+                    double azimuthForCameraMode = (Math.toDegrees((double) SensorManager.getOrientation(rMat, orientation)[0]) - Math.toDegrees((double) SensorManager.getOrientation(rMat, orientation)[2]) + (double) 360) % (double) 360;
+                    double[] v = new double[3];
+                    v[0] = newAzimuth;
+                    v[1] = azimuthForCameraMode;
+                    v[2] = null;
+                    events.success(v);
                 }
             }
         };
@@ -69,6 +74,7 @@ public final class FlutterCompassPlugin implements StreamHandler {
 
     private FlutterCompassPlugin(Context context, int sensorType, int fallbackSensorType) {
         filter = 1.0F;
+        lastAccuracy = 1; // SENSOR_STATUS_ACCURACY_LOW
 
         sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
         orientation = new float[3];

--- a/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
+++ b/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
@@ -58,7 +58,7 @@ public final class FlutterCompassPlugin implements StreamHandler {
 
             public void onSensorChanged(SensorEvent event) {
                 SensorManager.getRotationMatrixFromVector(rMat, event.values);
-                newAzimuth = ((Math.toDegrees((double) SensorManager.getOrientation(rMat, orientation)[0]) + (double) 360) % (double) 360 - Math.toDegrees((double) SensorManager.getOrientation(rMat, orientation)[2]) + (double) 360) % (double) 360;
+                newAzimuth = (Math.toDegrees((double) SensorManager.getOrientation(rMat, orientation)[0]) + (double) 360) % (double) 360;
                 if (currentAzimuth == null || Math.abs(currentAzimuth - newAzimuth) >= filter) {
                     currentAzimuth = newAzimuth;
                     events.success(newAzimuth);

--- a/ios/Classes/SwiftFlutterCompassPlugin.swift
+++ b/ios/Classes/SwiftFlutterCompassPlugin.swift
@@ -37,7 +37,7 @@ public class SwiftFlutterCompassPlugin: NSObject, FlutterPlugin, FlutterStreamHa
         if(newHeading.headingAccuracy>0){
             let heading:CLLocationDirection!;
             heading = newHeading.magneticHeading;
-            eventSink?(heading);
+            eventSink?([heading, heading, newHeading.headingAccuracy]);
         }
     }
 }

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -10,7 +10,7 @@ class CompassEvent {
   CompassEvent.fromList(List<double> data)
     : heading = data[0],
       headingForCameraMode = data[1],
-      accuracy = data[2];
+      accuracy = data[2] == -1 ? null : data[2];
 }
 
 /// [FlutterCompass] is a singleton class that provides assess to compass events

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -3,6 +3,16 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:rxdart/subjects.dart';
 
+class CompassEvent {
+  final double heading;
+  final double headingForCameraMode;
+  final double accuracy;
+  CompassEvent.fromList(List<double> data)
+    : heading = data[0],
+      headingForCameraMode = data[1],
+      accuracy = data[2];
+}
+
 /// [FlutterCompass] is a singleton class that provides assess to compass events
 /// The heading varies from 0-360, 0 being north.
 class FlutterCompass {
@@ -17,15 +27,15 @@ class FlutterCompass {
   static const EventChannel _compassChannel =
       const EventChannel('hemanthraj/flutter_compass');
 
-  BehaviorSubject<double> _compassEvents;
+  BehaviorSubject<CompassEvent> _compassEvents;
 
   /// Provides a [Stream] of compass events that can be listened to.
-  static Stream<double> get events {
+  static Stream<CompassEvent> get events {
     if (_instance._compassEvents == null) {
-      _instance._compassEvents = BehaviorSubject<double>();
+      _instance._compassEvents = BehaviorSubject<CompassEvent>();
       _instance._compassEvents.addStream(_compassChannel
           .receiveBroadcastStream()
-          .map<double>((dynamic data) => data));
+          .map((dynamic data) => CompassEvent.fromList(data.cast<double>())));
     }
 
     return _instance._compassEvents;


### PR DESCRIPTION
This was a difference in heading results between iOS and Android. It is unclear
why the original author opted for this solution, as it produced incorrect headings when
the phone was rolled side-to-side.