### PR TITLE
Improve heading calculation for "camera mode"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.0
+
+**Breaking Change:** The `events` stream now gives you `CompassEvent` that consists of `heading`, `headingForCamera` and `accuracy`.
+
+Android: Remove roll from heading calculations 
+
 ## 0.4.3
 
 Use geomagnetic rotation sensor as fallback on Android

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Make sure to add keys with appropriate descriptions to the `Info.plist` file.
 Make sure to add permissions to the `app/src/main/AndroidManifest.xml` file.
 
 * `android.permission.INTERNET`
-* `android.permission.ACCESS_COARSE_LOCATIO`
+* `android.permission.ACCESS_COARSE_LOCATION`
 * `android.permission.ACCESS_FINE_LOCATION`
 
 :memo: [Reference example code](https://github.com/hemanthrajv/flutter_compass/blob/89dccd39a32af970322b237e574d2e6fa3454568/example/android/app/src/main/AndroidManifest.xml#L4-L10)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,6 @@
+#Wed Oct 14 23:53:48 IST 2020
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
+++ b/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
@@ -73,7 +73,7 @@ public final class FlutterCompassPlugin implements StreamHandler {
     }
 
     private FlutterCompassPlugin(Context context, int sensorType, int fallbackSensorType) {
-        filter = 1.0F;
+        filter = 0.1F;
         lastAccuracy = 1; // SENSOR_STATUS_ACCURACY_LOW
 
         sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);

--- a/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
+++ b/android/src/main/java/com/hemanthraj/fluttercompass/FlutterCompassPlugin.java
@@ -75,11 +75,16 @@ public final class FlutterCompassPlugin implements StreamHandler {
                     double[] v = new double[3];
                     v[0] = newAzimuth;
                     v[1] = azimuthForCameraMode;
-                    // Include reasonable compass accuracy numbers.
+                    // Include reasonable compass accuracy numbers. These are not representative
+                    // of the real error.
                     if (lastAccuracy == SensorManager.SENSOR_STATUS_ACCURACY_HIGH) {
-                        v[2] = 15; // +/- 15deg
+                        v[2] = 15;
+                    } else if (lastAccuracy == SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM) {
+                        v[2] = 30;
+                    } else if (lastAccuracy == SensorManager.SENSOR_STATUS_ACCURACY_LOW) {
+                        v[2] = 45;
                     } else {
-                        v[2] = 90; // +/- 90 deg
+                        v[2] = -1; // unknown
                     }
                     events.success(v);
                 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   bool _hasPermissions = false;
-  double _lastRead = 0;
+  CompassEvent _lastRead;
   DateTime _lastReadAt;
 
   @override
@@ -59,7 +59,7 @@ class _MyAppState extends State<MyApp> {
           RaisedButton(
             child: Text('Read Value'),
             onPressed: () async {
-              final double tmp = await FlutterCompass.events.first;
+              final CompassEvent tmp = await FlutterCompass.events.first;
               setState(() {
                 _lastRead = tmp;
                 _lastReadAt = DateTime.now();
@@ -67,18 +67,21 @@ class _MyAppState extends State<MyApp> {
             },
           ),
           Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              children: <Widget>[
-                Text(
-                  '$_lastRead',
-                  style: Theme.of(context).textTheme.caption,
-                ),
-                Text(
-                  '$_lastReadAt',
-                  style: Theme.of(context).textTheme.caption,
-                ),
-              ],
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    '$_lastRead',
+                    style: Theme.of(context).textTheme.caption,
+                  ),
+                  Text(
+                    '$_lastReadAt',
+                    style: Theme.of(context).textTheme.caption,
+                  ),
+                ],
+              ),
             ),
           ),
         ],
@@ -87,7 +90,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   Widget _buildCompass() {
-    return StreamBuilder<double>(
+    return StreamBuilder<CompassEvent>(
       stream: FlutterCompass.events,
       builder: (context, snapshot) {
         if (snapshot.hasError) {
@@ -100,7 +103,7 @@ class _MyAppState extends State<MyApp> {
           );
         }
 
-        double direction = snapshot.data;
+        double direction = snapshot.data.heading;
 
         // if direction is null, then device does not support this sensor
         // show error message
@@ -109,11 +112,20 @@ class _MyAppState extends State<MyApp> {
             child: Text("Device does not have sensors !"),
           );
 
-        return Container(
-          alignment: Alignment.center,
-          child: Transform.rotate(
-            angle: ((direction ?? 0) * (math.pi / 180) * -1),
-            child: Image.asset('assets/compass.jpg'),
+        return Material(
+          shape: CircleBorder(),
+          clipBehavior: Clip.antiAlias,
+          elevation: 4.0,
+          child: Container(
+            padding: EdgeInsets.all(16.0),
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+            ),
+            child: Transform.rotate(
+              angle: ((direction ?? 0) * (math.pi / 180) * -1),
+              child: Image.asset('assets/compass.jpg'),
+            ),
           ),
         );
       },

--- a/ios/Classes/SwiftFlutterCompassPlugin.swift
+++ b/ios/Classes/SwiftFlutterCompassPlugin.swift
@@ -10,7 +10,7 @@ public class SwiftFlutterCompassPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     init(channel: FlutterEventChannel) {
         super.init()
         location.delegate = self
-        location.headingFilter = 1;
+        location.headingFilter = 0.1;
         channel.setStreamHandler(self);
     }
 

--- a/ios/Classes/SwiftFlutterCompassPlugin.swift
+++ b/ios/Classes/SwiftFlutterCompassPlugin.swift
@@ -1,17 +1,23 @@
 import Flutter
 import UIKit
 import CoreLocation
+import CoreMotion
 
 public class SwiftFlutterCompassPlugin: NSObject, FlutterPlugin, FlutterStreamHandler, CLLocationManagerDelegate {
 
     private var eventSink: FlutterEventSink?;
     private var location: CLLocationManager = CLLocationManager();
+    private var motion: CMMotionManager = CMMotionManager();
+
 
     init(channel: FlutterEventChannel) {
         super.init()
         location.delegate = self
         location.headingFilter = 0.1;
         channel.setStreamHandler(self);
+
+        motion.accelerometerUpdateInterval = 1.0 / 30.0;
+        motion.startAccelerometerUpdates();
     }
 
 
@@ -34,10 +40,19 @@ public class SwiftFlutterCompassPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     }
 
     public func locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
-        if(newHeading.headingAccuracy>0){
-            let heading:CLLocationDirection!;
-            heading = newHeading.magneticHeading;
-            eventSink?([heading, heading, newHeading.headingAccuracy]);
+        if (newHeading.headingAccuracy>0){
+            var headingForCameraMode = newHeading.magneticHeading;
+            if let data = self.motion.accelerometerData {
+                headingForCameraMode = newHeading.magneticHeading + atan2(-data.acceleration.x, -data.acceleration.y) 
+                    * 180.0 / Double.pi;
+                while (headingForCameraMode >= 360.0) {
+                    headingForCameraMode -= 360.0;
+                }
+                while (headingForCameraMode < 360.0) {
+                    headingForCameraMode += 360.0;
+                }
+            }
+            eventSink?([newHeading.magneticHeading, headingForCameraMode, newHeading.headingAccuracy]);
         }
     }
 }

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -4,8 +4,18 @@ import 'package:flutter/services.dart';
 import 'package:rxdart/subjects.dart';
 
 class CompassEvent {
+  // The heading, in degrees, of the device relative to the its Y
+  // axis, or where the top of the device is pointing.
   final double heading;
+
+  // The heading, in degrees, of the device relative to its X axis, or
+  // where the back of the device is pointing.
   final double headingForCameraMode;
+
+  // The deviation error, in degrees, plus or minus from the heading.
+  // NOTE: for iOS this is computed by the platform and is reliable. For
+  // Android several values are hard-coded, and the true error could be more
+  // or less than the value here.
   final double accuracy;
 
   CompassEvent.fromList(List<double> data)

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -4,11 +4,11 @@ import 'package:flutter/services.dart';
 import 'package:rxdart/subjects.dart';
 
 class CompassEvent {
-  // The heading, in degrees, of the device relative to the its Y
+  // The heading, in degrees, of the device around its Z
   // axis, or where the top of the device is pointing.
   final double heading;
 
-  // The heading, in degrees, of the device relative to its X axis, or
+  // The heading, in degrees, of the device around its X axis, or
   // where the back of the device is pointing.
   final double headingForCameraMode;
 

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -34,20 +34,29 @@ class FlutterCompass {
       const EventChannel('hemanthraj/flutter_compass');
 
   BehaviorSubject<CompassEvent> _compassEvents;
+  static StreamSubscription _sub;
 
   /// Provides a [Stream] of compass events that can be listened to.
   static Stream<CompassEvent> get events {
     if (_instance._compassEvents == null) {
       _instance._compassEvents = BehaviorSubject<CompassEvent>();
-      _instance._compassEvents.addStream(_compassChannel
-          .receiveBroadcastStream()
-          .map((dynamic data) => CompassEvent.fromList(data.cast<double>())));
+      if (_sub == null) {
+        _sub = _compassChannel
+            .receiveBroadcastStream()
+            .map((dynamic data) => CompassEvent.fromList(data.cast<double>()))
+            .listen(
+              (event) => _instance._compassEvents.add(event),
+              onError: _instance._compassEvents.addError,
+            );
+      }
     }
 
     return _instance._compassEvents;
   }
 
   void dispose() {
+    _sub?.cancel();
+    _sub = null;
     _compassEvents?.close();
     _compassEvents = null;
   }

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -7,10 +7,16 @@ class CompassEvent {
   final double heading;
   final double headingForCameraMode;
   final double accuracy;
+
   CompassEvent.fromList(List<double> data)
-    : heading = data[0],
-      headingForCameraMode = data[1],
-      accuracy = data[2] == -1 ? null : data[2];
+      : heading = data[0],
+        headingForCameraMode = data[1],
+        accuracy = data[2] == -1 ? null : data[2];
+
+  @override
+  String toString() {
+    return 'heading: $heading\nheadingForCameraMode: $headingForCameraMode\naccuracy: $accuracy';
+  }
 }
 
 /// [FlutterCompass] is a singleton class that provides assess to compass events

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_compass
 description: A Flutter compass. The heading varies from 0-360, 0 being north.
-version: 0.4.3
+version: 0.5.0
 homepage: https://github.com/hemanthrajv/flutter_compass
 
 dependencies:


### PR DESCRIPTION
Android: uses matrix reorientation to do a better job calculating heading "out the back of the phone"
iOS: uses a trigonometric correction based on accelerometer gravity for the same purpose.

Also:
* Reduce filter to 0.1. It's still not many values and some users fork only to do this one change.
* Add documentation to flutter_compass.dart.

(ps I don't know why the PR contains changes already in master)