### PR TITLE
Removed unnecessary BehaviorSubject (and the complete rxdart dependency).

### DIFF
--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:rxdart/subjects.dart';
 
 class CompassEvent {
   // The heading, in degrees, of the device around its Z
@@ -43,31 +42,11 @@ class FlutterCompass {
   static const EventChannel _compassChannel =
       const EventChannel('hemanthraj/flutter_compass');
 
-  BehaviorSubject<CompassEvent>? _compassEvents;
-  static StreamSubscription? _sub;
-
   /// Provides a [Stream] of compass events that can be listened to.
   static Stream<CompassEvent>? get events {
-    if (_instance._compassEvents == null) {
-      _instance._compassEvents = BehaviorSubject<CompassEvent>();
-      if (_sub == null) {
-        _sub = _compassChannel
-            .receiveBroadcastStream()
-            .map((dynamic data) => CompassEvent.fromList(data.cast<double>()))
-            .listen(
-              (event) => _instance._compassEvents!.add(event),
-              onError: _instance._compassEvents!.addError,
-            );
-      }
-    }
-
-    return _instance._compassEvents;
+    return _compassChannel
+        .receiveBroadcastStream()
+        .map((dynamic data) => CompassEvent.fromList(data.cast<double>()));
   }
 
-  void dispose() {
-    _sub?.cancel();
-    _sub = null;
-    _compassEvents?.close();
-    _compassEvents = null;
-  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,6 @@ homepage: https://github.com/hemanthrajv/flutter_compass
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.26.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
The stream received from the channel is already a broadcast stream, and keeping one event cached (as BehaviorSubject does) has absolutely no advantage here, it just adds an unnecessary layer.
What's more, with the original code, cancelling the stream in the app is not enough when the activity is closed, because the following message keeps appearing: "Tried to send a platform message to Flutter, but FlutterJNI was detached from native C++. Could not send. Channel: hemanthraj/flutter_compass"
Alternative solution, if for some reason BehaviorSubject is strictly required: keep the `dispose()` method, and change the initialization to the following:
```
_instance._compassEvents = BehaviorSubject<CompassEvent>(
  onCancel: _instance.dispose
);
```