### PR TITLE
Fix bug: allow multiple listeners to compass stream.

### DIFF
--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -41,12 +41,15 @@ class FlutterCompass {
 
   static const EventChannel _compassChannel =
       const EventChannel('hemanthraj/flutter_compass');
+  static Stream<CompassEvent>? _stream;
 
   /// Provides a [Stream] of compass events that can be listened to.
   static Stream<CompassEvent>? get events {
-    return _compassChannel
-        .receiveBroadcastStream()
-        .map((dynamic data) => CompassEvent.fromList(data.cast<double>()));
+    if (_stream == null) {
+      _stream = _compassChannel
+          .receiveBroadcastStream()
+          .map((dynamic data) => CompassEvent.fromList(data.cast<double>()));
+    }
+    return _stream;
   }
-
 }


### PR DESCRIPTION
recieveBroadcastStream() *is* a broadcast stream, but that breaks if
you create it every time someone asks for the stream to listen to.

This change caches the stream itself in a static member variable and
vends it when requested.