### PR TITLE
Bug Fix: The method 'cast' was called on null.

### DIFF
--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -17,10 +17,10 @@ class CompassEvent {
   // or less than the value here.
   final double? accuracy;
 
-  CompassEvent.fromList(List<double> data)
-      : heading = data[0],
-        headingForCameraMode = data[1],
-        accuracy = data[2] == -1 ? null : data[2];
+  CompassEvent.fromList(List<double>? data)
+      : heading = data?[0] ?? null,
+        headingForCameraMode = data?[1] ?? null,
+        accuracy = (data == null) || (data[2] == -1) ? null : data[2];
 
   @override
   String toString() {
@@ -48,5 +48,4 @@ class FlutterCompass {
         .receiveBroadcastStream()
         .map((dynamic data) => CompassEvent.fromList(data.cast<double>()));
   }
-
 }

--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -46,6 +46,6 @@ class FlutterCompass {
   static Stream<CompassEvent>? get events {
     return _compassChannel
         .receiveBroadcastStream()
-        .map((dynamic data) => CompassEvent.fromList(data.cast<double>()));
+        .map((dynamic data) => CompassEvent.fromList(data?.cast<double>()));
   }
 }


### PR DESCRIPTION
Devices without a magnetometer sensor throw this error:

`NoSuchMethodError: NoSuchMethodError: The method 'cast' was called on null.`

This PR attempts to fix this issue.