### PR TITLE
Revert minSdkVersion back to 20

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 20
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
Revert minSdkVersion back to 20 to keep supporting older API levels. Having minSdkVersionat 20 seems to work just fine on older APIs.