### PR TITLE
Revert minSdkVersion to 16 (works ok).

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 20
+        minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {


### PR DESCRIPTION
You can leave the minSdkVersion as 16 (I needed to support some old device), and no issues compiling.