### PR TITLE
Non-nullable events

### DIFF
--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -44,10 +44,10 @@ class FlutterCompass {
   static Stream<CompassEvent>? _stream;
 
   /// Provides a [Stream] of compass events that can be listened to.
-  static Stream<CompassEvent>? get events {
+  static Stream<CompassEvent> get events {
     _stream ??= _compassChannel
         .receiveBroadcastStream()
         .map((dynamic data) => CompassEvent.fromList(data?.cast<double>()));
-    return _stream;
+    return _stream!;
   }
 }


### PR DESCRIPTION
The `events` getter is never null, so better to mark it as non-nullable.