### PR TITLE
Avoid web error

### DIFF
--- a/lib/flutter_compass.dart
+++ b/lib/flutter_compass.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 class CompassEvent {
@@ -45,6 +46,9 @@ class FlutterCompass {
 
   /// Provides a [Stream] of compass events that can be listened to.
   static Stream<CompassEvent>? get events {
+    if (kIsWeb) {
+      return Stream.empty();
+    }
     _stream ??= _compassChannel
         .receiveBroadcastStream()
         .map((dynamic data) => CompassEvent.fromList(data?.cast<double>()));


### PR DESCRIPTION
An error occur when calling `FlutterCompass.events`.

```
════════ Exception caught by services library ══════════════════════════════════
The following MissingPluginException was thrown while activating platform stream on channel hemanthraj[/flutter_compass]():
MissingPluginException(No implementation found for method listen on channel hemanthraj[/flutter_compass]())

When the exception was thrown, this was the stack
dart-sdk[/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart]() 251:49  throw_
packages[/flutter/src/services/platform_channel.dart]() 175:7                     _invokeMethod
dart-sdk[/lib/_internal/js_dev_runtime/patch/async_patch.dart]() 45:50            <fn>
dart-sdk[/lib/async/zone.dart]() 1685:54                                          runUnary
dart-sdk[/lib/async/future_impl.dart]() 159:18                                    handleValue
dart-sdk[/lib/async/future_impl.dart]() 766:44                                    handleValueCallback
dart-sdk[/lib/async/future_impl.dart]() 795:13                                    _propagateToListeners
dart-sdk[/lib/async/future_impl.dart]() 601:5                                     [_completeWithValue]
dart-sdk[/lib/async/future_impl.dart]() 639:7                                     callback
dart-sdk[/lib/async/schedule_microtask.dart]() 40:11                              _microtaskLoop
dart-sdk[/lib/async/schedule_microtask.dart]() 49:5                               _startMicrotaskLoop
dart-sdk[/lib/_internal/js_dev_runtime/patch/async_patch.dart]() 166:15           <fn>
════════════════════════════════════════════════════════════════════════════════
```