### PR TITLE
Android Gradle Plugin >8.0.0 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,6 +23,10 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 30
+    
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.hemanthraj.fluttercompass'
+    }
 
     defaultConfig {
         minSdkVersion 20

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -16,6 +16,10 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 30
+    
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.hemanthraj.fluttercompassexample'
+    }
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
Added `namespace` property to the build.gradle files for compatibility with Android Gradle Plugin 8.0.0 to the build.gradle files.