### PR TITLE
[FIX] Support newer Android version and AGP >=8.0.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+* Bump the compileSdkVersion to 34 to support Android 14
+* Support the AGP >= 8
+
 ## 0.8.0
 * Add guard on web (Web always returns an empty stream)
 * Heading accounts for orientation on iOS

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use this plugin, add `flutter_compass` as a [dependency in your pubspec.yaml 
 
 ```yaml
 dependencies:
-  flutter_compass: '^0.7.0'
+  flutter_compass: '^0.8.1'
 ```
 
 ### iOS

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
+
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.hemanthraj.fluttercompass'
+    }
 
     defaultConfig {
         minSdkVersion 20

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -15,7 +15,11 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 34
+
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.hemanthraj.fluttercompass'
+    }
 
     lintOptions {
         disable 'InvalidPackage'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_compass
 description: A Flutter compass. The heading varies from 0-360, 0 being north.
-version: 0.8.0
+version: 0.8.1
 homepage: https://github.com/hemanthrajv/flutter_compass
 
 dependencies:
@@ -8,8 +8,8 @@ dependencies:
     sdk: flutter
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
-  flutter: '>=1.10.0'
+  sdk: ">=2.12.0 <4.0.0"
+  flutter: ">=1.10.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
AGP >= 8 need to specify a namespace (https://github.com/hemanthrajv/flutter_compass/issues/104)
We need to update the compileSdk version due to this error "resource android:attr/lStar not found" since Android 12 so update to support 14 and lower (https://github.com/hemanthrajv/flutter_compass/issues/112)